### PR TITLE
Support of recipient variables

### DIFF
--- a/Mail/Hailgun/Internal/Data.hs
+++ b/Mail/Hailgun/Internal/Data.hs
@@ -23,6 +23,7 @@ import           Data.Aeson
 import qualified Data.ByteString      as B
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text            as T
+import qualified Data.Map             as M
 import           Data.Time.Clock      (UTCTime (..))
 #if MIN_VERSION_time(1,6,0)
 import           Data.Time.Format     (ParseTime (..), parseTimeM)
@@ -94,6 +95,7 @@ data HailgunMessage = HailgunMessage
    , messageCC          :: [VerifiedEmailAddress]
    , messageBCC         :: [VerifiedEmailAddress]
    , messageAttachments :: [SpecificAttachment]
+   , messageVariables   :: M.Map VerifiedEmailAddress Value
    }
    deriving (Show)
    -- TODO o:tag support

--- a/hailgun.cabal
+++ b/hailgun.cabal
@@ -86,6 +86,7 @@ library
                         , transformers       >= 0.3 && < 0.6
                         , filepath           >= 1 && < 2
                         , attoparsec         >= 0.13 && < 0.14
+                        , containers
 
    if flag(newtime)
       Build-Depends:    time >= 1.5


### PR DESCRIPTION
This should allow to send few personalized emails
interpolated by recipient variables (according to [documentation](https://documentation.mailgun.com/en/latest/user_manual.html#batch-sending)).

I have tested it with simple CLI small tool taken from [here](https://hackage.haskell.org/package/hailgun-send).